### PR TITLE
Fix input issue

### DIFF
--- a/x1.ino
+++ b/x1.ino
@@ -23,6 +23,7 @@ void loop() {
   }
   
   unsigned long newmillis = millis();
+  
   if (newmillis - oldmillis >= interval){
       oldmillis = newmillis;
      Serial.println(voltage);

--- a/x1.ino
+++ b/x1.ino
@@ -20,9 +20,6 @@ void loop() {
   if (Serial.available() > 0) {
     voltage = Serial.parseInt();
     Serial.read();  // consume newline character
-
-    Serial.print("Got: ");
-    Serial.println(voltage);
   }
   
   unsigned long newmillis = millis();

--- a/x1.ino
+++ b/x1.ino
@@ -22,7 +22,7 @@ void loop() {
     Serial.read();  // consume newline character
 
     Serial.print("Got: ");
-    Serial.println(votage);
+    Serial.println(voltage);
   }
   
   unsigned long newmillis = millis();

--- a/x1.ino
+++ b/x1.ino
@@ -17,18 +17,15 @@ void setup() {
 }
 
 void loop() {
+  if (Serial.available() > 0) {
+    voltage = Serial.parseInt();
+    Serial.read();  // consume newline character
 
-  unsigned long newserial = Serial.available();
-
-   if (newserial != oldserial){
-        oldserial = newserial;
-        voltage = Serial.parseInt();
-       Serial.println("Enter new voltage");
-  
+    Serial.print("Got: ");
+    Serial.println(votage);
   }
   
   unsigned long newmillis = millis();
-
   if (newmillis - oldmillis >= interval){
       oldmillis = newmillis;
      Serial.println(voltage);


### PR DESCRIPTION
First, `Serial.available()` tells you how many unconsumed bytes are in the stream. When you use `.parseInt()` it will consume all bytes that are numbers and leave the invisible new-line character `\n`. This means there is a byte left in the stream, so the next time the loop happens, it converts that `\n` character into an int. all unconvertable bytes will be converted as `0`. Which is why, it was resetting to `0` all the time.